### PR TITLE
Set application status as FOREGROUND when enable BrowserLock

### DIFF
--- a/src/org/triple/banana/lock/ApplicationStatusTracker.java
+++ b/src/org/triple/banana/lock/ApplicationStatusTracker.java
@@ -68,6 +68,7 @@ public class ApplicationStatusTracker {
     }
 
     public void start() {
+        mCurrentStatus = ApplicationStatus.FOREGROUND;
         BananaApplicationUtils.get().registerApplicationStateListener(mApplicationStateListener);
         BananaApplicationUtils.get().registerStateListenerForAllActivities(mActivityStateListener);
     }


### PR DESCRIPTION
Initial status value is UNSPECIFIED so after enabling BrowserLock,
if user back to main activity, is triggers FOREGROUND event.
So, when enable BrowserLock, mCurrentStatus should be set to FOREGROUND.

Refs: #681