### PR TITLE
Fix a crash when entering fullscreen mode with MediaRemote

### DIFF
--- a/src/org/triple/banana/media_remote/MediaRemoteViewImpl.java
+++ b/src/org/triple/banana/media_remote/MediaRemoteViewImpl.java
@@ -114,7 +114,6 @@ class MediaRemoteViewImpl implements MediaRemoteView, MediaRemoteViewModel.Liste
     }
 
     private void createDialog(@NonNull Activity parentActivity) {
-        if (mDialog != null) return;
         mDialog = new Dialog(parentActivity, R.style.Theme_Banana_Fullscreen_Transparent_Dialog);
         mDialog.setCancelable(false);
         mDialog.setOnKeyListener(mCancelListener);
@@ -211,7 +210,7 @@ class MediaRemoteViewImpl implements MediaRemoteView, MediaRemoteViewModel.Liste
 
     @Override
     public void show(@NonNull Activity parentActivity) {
-        if (parentActivity.isFinishing()) return;
+        if (parentActivity.isFinishing() || parentActivity.isDestroyed()) return;
 
         createDialog(parentActivity);
 


### PR DESCRIPTION
A crash occurs sometimes when entering fullscreen mode with MediaRemote.
It is caused when the parent of the dialog is no longer valid. In the
current implementation, we are caching the dialog instance and then
re-using it in media remote view. But if the parent is no longer valid,
it causes a crash when the mDialog.show() is called. Moreover, the
parent activity's instance might be changed in some cases, so, we should
recreate it whenver the show() method in media remote view is called.

Refs: #714