### PR TITLE
Implement banana cake local state 

### DIFF
--- a/banana_cake/cpp/cake_local_state.cc
+++ b/banana_cake/cpp/cake_local_state.cc
@@ -1,0 +1,19 @@
+// Copyright 2020 The Triple Banana Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <jni.h>
+
+#include "base/android/jni_string.h"
+#include "chrome/android/chrome_jni_headers/CakeLocalState_jni.h"
+#include "chrome/browser/browser_process.h"
+#include "components/prefs/pref_service.h"
+
+static base::android::ScopedJavaLocalRef<jstring> JNI_CakeLocalState_GetString(
+    JNIEnv* env,
+    const base::android::JavaParamRef<jstring>& key) {
+  const std::string& value = g_browser_process->local_state()->GetString(
+      base::android::ConvertJavaStringToUTF8(key));
+  return base::android::ConvertUTF8ToJavaString(env, value);
+}

--- a/banana_cake/interfaces/java/org/banana/cake/interfaces/BananaLocalState.java
+++ b/banana_cake/interfaces/java/org/banana/cake/interfaces/BananaLocalState.java
@@ -1,0 +1,14 @@
+// Copyright 2020 The Triple Banana Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package org.banana.cake.interfaces;
+
+public interface BananaLocalState {
+    static BananaLocalState get() {
+        return BananaInterfaceProvider.get(BananaLocalState.class);
+    }
+
+    boolean isSecureDNSMode();
+}

--- a/banana_cake/java/org/banana/cake/CakeInterfaceProvider.java
+++ b/banana_cake/java/org/banana/cake/CakeInterfaceProvider.java
@@ -21,6 +21,7 @@ import org.banana.cake.interfaces.BananaCommandLine;
 import org.banana.cake.interfaces.BananaDarkModeUtils;
 import org.banana.cake.interfaces.BananaFeatureFlags;
 import org.banana.cake.interfaces.BananaInterfaceProvider;
+import org.banana.cake.interfaces.BananaLocalState;
 import org.banana.cake.interfaces.BananaPipController;
 import org.banana.cake.interfaces.BananaSubresourceFilter;
 import org.banana.cake.interfaces.BananaTab;
@@ -46,6 +47,8 @@ public class CakeInterfaceProvider {
         BananaInterfaceProvider.register(BananaToolbarManager.class, CakeToolbarManager::new,
                 BananaInterfaceProvider.InstanceType.SINGLETON);
         BananaInterfaceProvider.register(BananaClearBrowsingData.class, CakeClearBrowsingData::new,
+                BananaInterfaceProvider.InstanceType.SINGLETON);
+        BananaInterfaceProvider.register(BananaLocalState.class, CakeLocalState::new,
                 BananaInterfaceProvider.InstanceType.SINGLETON);
     }
 }

--- a/banana_cake/java/org/banana/cake/CakeLocalState.java
+++ b/banana_cake/java/org/banana/cake/CakeLocalState.java
@@ -1,0 +1,26 @@
+// Copyright 2020 The Triple Banana Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package org.banana.cake;
+
+import androidx.annotation.NonNull;
+
+import org.banana.cake.interfaces.BananaLocalState;
+
+import org.chromium.base.annotations.NativeMethods;
+import org.chromium.chrome.browser.preferences.Pref;
+
+public class CakeLocalState implements BananaLocalState {
+    @Override
+    public boolean isSecureDNSMode() {
+        return !CakeLocalStateJni.get().getString(Pref.DNS_OVER_HTTPS_MODE).equals("off");
+    }
+
+    @NativeMethods
+    interface Natives {
+        @NonNull
+        String getString(@NonNull String key);
+    }
+}

--- a/triple_banana.gni
+++ b/triple_banana.gni
@@ -15,6 +15,7 @@ triple_banana_hooks_sources = [
   "//triple_banana/banana_cake/interfaces/java/org/banana/cake/interfaces/BananaFeatureFlags.java",
   "//triple_banana/banana_cake/interfaces/java/org/banana/cake/interfaces/BananaInterfaceProvider.java",
   "//triple_banana/banana_cake/interfaces/java/org/banana/cake/interfaces/BananaJavaScriptCallback.java",
+  "//triple_banana/banana_cake/interfaces/java/org/banana/cake/interfaces/BananaLocalState.java",
   "//triple_banana/banana_cake/interfaces/java/org/banana/cake/interfaces/BananaPasswordExtension.java",
   "//triple_banana/banana_cake/interfaces/java/org/banana/cake/interfaces/BananaPipController.java",
   "//triple_banana/banana_cake/interfaces/java/org/banana/cake/interfaces/BananaSubresourceFilter.java",
@@ -28,9 +29,11 @@ triple_banana_hooks_sources = [
 ]
 
 triple_banana_jni_sources = [
+  "//triple_banana/banana_cake/java/org/banana/cake/CakeLocalState.java",
   "//triple_banana/banana_cake/java/org/banana/cake/CakeSubresourceFilter.java",
 ]
 
 triple_banana_native_sources = [
+  "//triple_banana/banana_cake/cpp/cake_local_state.cc",
   "//triple_banana/banana_cake/cpp/cake_subresource_filter.cc",
- ]
+]


### PR DESCRIPTION
This patch implements banana cake local state to get/set value from the
local state. It accesses the local state using the JNI Bridge.

Refs: #888