### PR TITLE
Fix a bug the play state doesn't work in media remote

### DIFF
--- a/proguard.flags
+++ b/proguard.flags
@@ -4,3 +4,4 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 -keep public class org.triple.banana.settings.*
+-keep public class org.triple.banana.media.MediaPlayState


### PR DESCRIPTION
This patch fixes a bug the play state doesn't work in the media remote.
The reason why it doesn't work is proguard. To resolve this issue, we
exclude this enum class in proguard.flags.

Refs: #968