### PR TITLE
Enable CECPQ2 feature without restarting browser

### DIFF
--- a/upstream/tb_net_socket_ssl_client_socket_impl.cc.patch
+++ b/upstream/tb_net_socket_ssl_client_socket_impl.cc.patch
@@ -1,0 +1,26 @@
+diff --git tb/net/socket/ssl_client_socket_impl.cc tb_diff/net/socket/ssl_client_socket_impl.cc
+--- tb/net/socket/ssl_client_socket_impl.cc
++++ tb_diff/net/socket/ssl_client_socket_impl.cc
+@@ -761,9 +761,22 @@ int SSLClientSocketImpl::Init() {
+   DCHECK(!ssl_);
+ 
+   SSLContext* context = SSLContext::GetInstance();
++#if defined(ENABLE_TRIPLE_BANANA)
++  if (!base::FeatureList::IsEnabled(features::kPostQuantumCECPQ2)) {
++    if (ssl_config_.secure_dns_mode == SecureDnsMode::kSecure) {
++      const int kCurves[] = {NID_CECPQ2, NID_X25519, NID_X9_62_prime256v1,
++                             NID_secp384r1};
++      SSL_CTX_set1_curves(context->ssl_ctx(), kCurves, base::size(kCurves));
++    } else {
++      SSL_CTX_set1_curves(context->ssl_ctx(), nullptr, 0);
++    }
++  }
++#endif
++
+   crypto::OpenSSLErrStackTracer err_tracer(FROM_HERE);
+ 
+   ssl_.reset(SSL_new(context->ssl_ctx()));
++
+   if (!ssl_ || !context->SetClientSocketForSSL(ssl_.get(), this))
+     return ERR_UNEXPECTED;
+ 

--- a/upstream/tb_net_socket_ssl_connect_job.cc.patch
+++ b/upstream/tb_net_socket_ssl_connect_job.cc.patch
@@ -1,0 +1,28 @@
+diff --git tb/net/socket/ssl_connect_job.cc tb_diff/net/socket/ssl_connect_job.cc
+--- tb/net/socket/ssl_connect_job.cc
++++ tb_diff/net/socket/ssl_connect_job.cc
+@@ -35,6 +35,10 @@
+ #include "third_party/boringssl/src/include/openssl/pool.h"
+ #include "third_party/boringssl/src/include/openssl/ssl.h"
+ 
++#if defined(ENABLE_TRIPLE_BANANA)
++#include "net/dns/public/secure_dns_mode.h"
++#endif
++
+ namespace net {
+ 
+ namespace {
+@@ -366,6 +370,13 @@ int SSLConnectJob::DoSSLConnect() {
+   ssl_config.network_isolation_key = params_->network_isolation_key();
+   ssl_config.privacy_mode = params_->privacy_mode();
+   ssl_config.disable_legacy_crypto = disable_legacy_crypto_with_fallback_;
++#if defined(ENABLE_TRIPLE_BANANA)
++  ssl_config.secure_dns_mode =
++      static_cast<SecureDnsMode>(host_resolver()
++                                     ->GetDnsConfigAsValue()
++                                     .FindIntKey("secure_dns_mode")
++                                     .value_or(0));
++#endif
+   ssl_socket_ = client_socket_factory()->CreateSSLClientSocket(
+       ssl_client_context(), std::move(nested_socket_), params_->host_and_port(),
+       ssl_config);

--- a/upstream/tb_net_ssl_ssl_config.h.patch
+++ b/upstream/tb_net_ssl_ssl_config.h.patch
@@ -1,0 +1,25 @@
+diff --git tb/net/ssl/ssl_config.h tb_diff/net/ssl/ssl_config.h
+--- tb/net/ssl/ssl_config.h
++++ tb_diff/net/ssl/ssl_config.h
+@@ -16,6 +16,10 @@
+ #include "net/socket/next_proto.h"
+ #include "net/ssl/ssl_private_key.h"
+ 
++#if defined(ENABLE_TRIPLE_BANANA)
++#include "net/dns/public/secure_dns_mode.h"
++#endif
++
+ namespace net {
+ 
+ // Various TLS/SSL ProtocolVersion values encoded as uint16_t
+@@ -141,6 +145,10 @@ struct NET_EXPORT SSLConfig {
+   // PartitionSSLSessionsByNetworkIsolationKey.
+   PrivacyMode privacy_mode = PRIVACY_MODE_DISABLED;
+ 
++#if defined(ENABLE_TRIPLE_BANANA)
++  SecureDnsMode secure_dns_mode = SecureDnsMode::kOff;
++#endif
++
+   // True if the post-handshake peeking of the transport should be skipped. This
+   // logic ensures tickets are resolved early, but can interfere with some unit
+   // tests.


### PR DESCRIPTION
This patch enables CECPQ2 feature without restarting the browser. When
secure DNS mode is turn on, enable CECPQ2 feature in a network.

Refs: #921