### PR TITLE
Show restart dialog when the secure dns mode is changed

### DIFF
--- a/banana_cake/interfaces/java/org/banana/cake/interfaces/BananaApplicationUtils.java
+++ b/banana_cake/interfaces/java/org/banana/cake/interfaces/BananaApplicationUtils.java
@@ -8,6 +8,7 @@ package org.banana.cake.interfaces;
 import android.content.Context;
 import android.content.SharedPreferences;
 
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 
 import org.chromium.base.ActivityState;
@@ -30,4 +31,5 @@ public interface BananaApplicationUtils {
     AlertDialog.Builder getDialogBuilder(Context context);
     void showInfoPage(String url);
     boolean isFirstInstall();
+    void showRestartDialog(@NonNull Context context);
 }

--- a/banana_cake/interfaces/java/org/banana/cake/interfaces/BananaSecureDnsSettings.java
+++ b/banana_cake/interfaces/java/org/banana/cake/interfaces/BananaSecureDnsSettings.java
@@ -5,6 +5,40 @@
 
 package org.banana.cake.interfaces;
 
+import android.content.SharedPreferences;
+import android.os.Bundle;
+
+import androidx.preference.Preference.OnPreferenceChangeListener;
+
 import org.chromium.chrome.browser.privacy.secure_dns.SecureDnsSettings;
 
-public class BananaSecureDnsSettings extends SecureDnsSettings {}
+public class BananaSecureDnsSettings extends SecureDnsSettings {
+    @Override
+    public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
+        super.onCreatePreferences(savedInstanceState, rootKey);
+        final OnPreferenceChangeListener listener =
+                mSecureDnsSwitch.getOnPreferenceChangeListener();
+        mSecureDnsSwitch.setOnPreferenceChangeListener((preference, enabled) -> {
+            if (listener != null) {
+                listener.onPreferenceChange(preference, enabled);
+                setSecureDnsEnabled((boolean) enabled);
+                BananaApplicationUtils.get().showRestartDialog(getContext());
+            }
+            return true;
+        });
+    }
+
+    private void setSecureDnsEnabled(final boolean enabled) {
+        final SharedPreferences.Editor editor =
+                BananaApplicationUtils.get().getSharedPreferences().edit();
+        editor.putBoolean("feature_name_secure_dns", enabled);
+
+        final boolean wasNotificationShown =
+                BananaApplicationUtils.get().getSharedPreferences().getBoolean(
+                        "feature_secure_dns_notification_shown", false);
+        if (enabled && wasNotificationShown) {
+            editor.putBoolean("feature_secure_dns_notification_shown", false);
+        }
+        editor.apply();
+    }
+}

--- a/banana_cake/java/org/banana/cake/CakeApplicationUtils.java
+++ b/banana_cake/java/org/banana/cake/CakeApplicationUtils.java
@@ -8,13 +8,14 @@ package org.banana.cake;
 import android.content.Context;
 import android.content.SharedPreferences;
 
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
 
 import org.banana.cake.interfaces.BananaApplicationUtils;
+import org.triple.banana.R;
 
 import org.chromium.base.ApplicationStatus;
 import org.chromium.base.ContextUtils;
-import org.chromium.chrome.R;
 import org.chromium.chrome.browser.ApplicationLifetime;
 import org.chromium.chrome.browser.customtabs.CustomTabActivity;
 import org.chromium.chrome.browser.firstrun.FirstRunStatus;
@@ -66,5 +67,15 @@ class CakeApplicationUtils implements BananaApplicationUtils {
     @Override
     public boolean isFirstInstall() {
         return !FirstRunStatus.getFirstRunFlowComplete();
+    }
+
+    @Override
+    public void showRestartDialog(@NonNull Context context) {
+        getDialogBuilder(context)
+                .setMessage(R.string.restart_message)
+                .setNegativeButton(android.R.string.cancel, null)
+                .setPositiveButton(android.R.string.ok, (dialog, which) -> restart())
+                .create()
+                .show();
     }
 }

--- a/src/org/triple/banana/settings/preference/RestartSwitchPreference.java
+++ b/src/org/triple/banana/settings/preference/RestartSwitchPreference.java
@@ -10,12 +10,10 @@ import android.util.AttributeSet;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.appcompat.app.AlertDialog;
 import androidx.preference.Preference;
 
 import org.banana.cake.interfaces.BananaApplicationUtils;
 import org.banana.cake.interfaces.BananaSwitchPreference;
-import org.triple.banana.R;
 
 class RestartSwitchPreference extends BananaSwitchPreference {
     protected RestartSwitchPreference(Context context, AttributeSet attrs) {
@@ -30,7 +28,7 @@ class RestartSwitchPreference extends BananaSwitchPreference {
             boolean isValueChanged =
                     ensureNonNull(listener).onPreferenceChange(preference, newValue);
             if (isValueChanged) {
-                showRestartDialog();
+                BananaApplicationUtils.get().showRestartDialog(getContext());
             }
             return isValueChanged;
         });
@@ -44,16 +42,5 @@ class RestartSwitchPreference extends BananaSwitchPreference {
             };
         }
         return listener;
-    }
-
-    private void showRestartDialog() {
-        BananaApplicationUtils.get()
-                .getDialogBuilder(getContext())
-                .setMessage(R.string.restart_message)
-                .setNegativeButton(android.R.string.cancel, null)
-                .setPositiveButton(android.R.string.ok,
-                        (dialog, which) -> { BananaApplicationUtils.get().restart(); })
-                .create()
-                .show();
     }
 }

--- a/upstream/tb_chrome_android_java_res_xml_privacy_preferences.xml.patch
+++ b/upstream/tb_chrome_android_java_res_xml_privacy_preferences.xml.patch
@@ -1,6 +1,15 @@
 diff --git tb/chrome/android/java/res/xml/privacy_preferences.xml tb_diff/chrome/android/java/res/xml/privacy_preferences.xml
 --- tb/chrome/android/java/res/xml/privacy_preferences.xml
 +++ tb_diff/chrome/android/java/res/xml/privacy_preferences.xml
+@@ -31,7 +31,7 @@
+     <org.chromium.components.browser_ui.settings.ChromeBasePreference
+         android:key="secure_dns"
+         android:title="@string/settings_secure_dns_title"
+-        android:fragment="org.chromium.chrome.browser.privacy.secure_dns.SecureDnsSettings"
++        android:fragment="org.banana.cake.interfaces.BananaSecureDnsSettings"
+         android:order="4"/>
+     <Preference
+         android:key="clear_browsing_data"
 @@ -46,6 +46,7 @@
          android:fragment="org.chromium.chrome.browser.safe_browsing.settings.SafeBrowsingSettingsFragment"
          android:order="6"/>

--- a/upstream/tb_chrome_browser_privacy_java_src_org_chromium_chrome_browser_privacy_secure_dns_SecureDnsSettings.java.patch
+++ b/upstream/tb_chrome_browser_privacy_java_src_org_chromium_chrome_browser_privacy_secure_dns_SecureDnsSettings.java.patch
@@ -1,6 +1,15 @@
 diff --git tb/chrome/browser/privacy/java/src/org/chromium/chrome/browser/privacy/secure_dns/SecureDnsSettings.java tb_diff/chrome/browser/privacy/java/src/org/chromium/chrome/browser/privacy/secure_dns/SecureDnsSettings.java
 --- tb/chrome/browser/privacy/java/src/org/chromium/chrome/browser/privacy/secure_dns/SecureDnsSettings.java
 +++ tb_diff/chrome/browser/privacy/java/src/org/chromium/chrome/browser/privacy/secure_dns/SecureDnsSettings.java
+@@ -27,7 +27,7 @@ public class SecureDnsSettings extends PreferenceFragmentCompat {
+     private static final String PREF_SECURE_DNS_SWITCH = "secure_dns_switch";
+     private static final String PREF_SECURE_DNS_PROVIDER = "secure_dns_provider";
+ 
+-    private ChromeSwitchPreference mSecureDnsSwitch;
++    protected ChromeSwitchPreference mSecureDnsSwitch;
+     private SecureDnsProviderPreference mSecureDnsProviderPreference;
+ 
+     public static boolean isUiEnabled() {
 @@ -67,6 +67,11 @@ public class SecureDnsSettings extends PreferenceFragmentCompat {
          mSecureDnsSwitch.setManagedPreferenceDelegate(
                  (ChromeManagedPreferenceDelegate) preference -> SecureDnsBridge.isModeManaged());


### PR DESCRIPTION
This patch shows the restart dialog when the secure dns mode is changed.
When a user turn on/off the secure dns switch preference, we inform the
user that the browser needs to be restarted for applying the secure dns
feature.

Refs: #921